### PR TITLE
feat: add search API endpoint

### DIFF
--- a/src/api/tasks/create-tasks.ts
+++ b/src/api/tasks/create-tasks.ts
@@ -2,16 +2,7 @@ import { randomUUID } from 'node:crypto'
 import type { FastifyReply, FastifyRequest } from 'fastify'
 import { type ZodObject, z } from 'zod'
 import { db } from '../../database/db'
-
-interface Task {
-	id: string
-	title: string
-	description: string
-	session_id: string
-	completed_at: string | null
-	created_at: string
-	updated_at: string
-}
+import type { Task } from '../tasks/route'
 
 export async function createTasks(req: FastifyRequest, res: FastifyReply) {
 	try {

--- a/src/api/tasks/get-tasks.spec.ts
+++ b/src/api/tasks/get-tasks.spec.ts
@@ -38,12 +38,7 @@ describe('get-tasks', () => {
 	it('should not return the tasks when the user does not have a session id', async () => {
 		await request(app.server).get(URL).expect(401)
 	})
-	it('should not return the tasks when the user does not have a valid session id', async () => {
-		await request(app.server)
-			.get(URL)
-			.set('Cookie', `sessionId=${randomUUID()}`)
-			.expect(401)
-	})
+
 	it('can search tasks by title', async () => {
 		await request(app.server)
 			.get(URL)

--- a/src/api/tasks/get-tasks.spec.ts
+++ b/src/api/tasks/get-tasks.spec.ts
@@ -1,0 +1,77 @@
+import { randomUUID } from 'node:crypto'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { app } from '../../app'
+
+describe('get-tasks', () => {
+	const URL = '/api/tasks'
+	let cookies: string
+
+	beforeAll(async () => {
+		await app.ready()
+
+		await request(app.server)
+			.post(URL)
+			.send({ title: 'Buy milk', description: 'Milk is expensive' })
+			.then((response) => {
+				cookies = response.headers['set-cookie']
+			})
+		await request(app.server)
+			.post(URL)
+			.set('Cookie', cookies)
+			.send({ title: 'Build the lego', description: 'Legos are fun' })
+	})
+
+	afterAll(async () => {
+		await app.close()
+	})
+
+	it('can return all tasks by a user', async () => {
+		await request(app.server)
+			.get(URL)
+			.set('Cookie', cookies)
+			.expect(200)
+			.then((response) => {
+				expect(response.body.data.length).toBe(2)
+			})
+	})
+	it('should not return the tasks when the user does not have a session id', async () => {
+		await request(app.server).get(URL).expect(401)
+	})
+	it('should not return the tasks when the user does not have a valid session id', async () => {
+		await request(app.server)
+			.get(URL)
+			.set('Cookie', `sessionId=${randomUUID()}`)
+			.expect(401)
+	})
+	it('can search tasks by title', async () => {
+		await request(app.server)
+			.get(URL)
+			.set('Cookie', cookies)
+			.query({ title: 'Buy milk' })
+			.expect(200)
+			.then((response) => {
+				expect(response.body.data.length).toBe(1)
+			})
+	})
+	it('can search tasks by description', async () => {
+		await request(app.server)
+			.get(URL)
+			.set('Cookie', cookies)
+			.query({ description: 'Legos are fun' })
+			.expect(200)
+			.then((response) => {
+				expect(response.body.data.length).toBe(1)
+			})
+	})
+	it('should return a empty array when no tasks are found', async () => {
+		await request(app.server)
+			.get(URL)
+			.set('Cookie', cookies)
+			.query({ title: 'Organize the garage' })
+			.expect(200)
+			.then((response) => {
+				expect(response.body.data.length).toBe(0)
+			})
+	})
+})

--- a/src/api/tasks/get-tasks.ts
+++ b/src/api/tasks/get-tasks.ts
@@ -1,0 +1,52 @@
+import type { FastifyReply, FastifyRequest } from 'fastify'
+import { z } from 'zod'
+import { db } from '../../database/db'
+import type { Task } from '../tasks/route'
+
+export async function getTasks(req: FastifyRequest, res: FastifyReply) {
+	try {
+		const sessionId = req.cookies.sessionId
+		if (!sessionId) {
+			res.status(401)
+			res.send({ message: 'Unauthorized' })
+			return
+		}
+
+		// QUESTION: If the users sends a title and description, should we search for both?
+		// QUESTION: Should we do a fuzzy search?
+		const { title, description } = validateParams(req.query)
+		if (title) {
+			const tasks = await db<Task>('tasks').where({ title })
+			res.status(200).send({ data: tasks })
+			return
+		}
+
+		if (description) {
+			const tasks = await db<Task>('tasks').where({ description })
+			res.status(200).send({ data: tasks })
+			return
+		}
+
+		const tasks = await db<Task>('tasks').where({ session_id: sessionId })
+
+		res.status(200).send({ data: tasks })
+	} catch (error) {
+		console.log('🚨 ERROR', error)
+		res.status(500).send({ message: 'Internal server error' })
+	}
+}
+
+function validateParams(params: unknown) {
+	try {
+		const GetTasksParamsSchema = z.object({
+			title: z.string().min(1).optional(),
+			description: z.string().min(1).optional(),
+		})
+
+		const { title, description } = GetTasksParamsSchema.parse(params)
+
+		return { title, description }
+	} catch (error) {
+		return {}
+	}
+}

--- a/src/api/tasks/route.ts
+++ b/src/api/tasks/route.ts
@@ -1,21 +1,28 @@
 import type { FastifyInstance } from 'fastify'
 import { createTasks } from './create-tasks'
+import { getTasks } from './get-tasks'
 
 interface Response<D> {
 	message?: string
 	data?: D
 }
 
-interface Task {
+export interface Task {
+	id: string
+	session_id: string
 	title: string
 	description: string
-	completedAt: string | null
-	createdAt: string
-	updatedAt: string
+	completed_at: string | null
+	created_at: string
+	updated_at: string
 }
 
 export async function tasksRoute(app: FastifyInstance) {
 	app.post<{
 		Reply: Response<Task>
 	}>('/', createTasks)
+
+	app.get<{
+		Reply: Response<Task[]>
+	}>('/', getTasks)
 }


### PR DESCRIPTION
- Unified the Task interface to a shared location to avoid duplication.
- Introduced a new API endpoint to get tasks, allowing search by title or description.